### PR TITLE
Load only 1000 nodes at a time

### DIFF
--- a/app/js/components/node.jsx
+++ b/app/js/components/node.jsx
@@ -439,8 +439,10 @@ var Node = React.createClass({
   */
 
   revealMoreNodesNotification: function(numHiddenChildren) {
+    var pclass = this.prefixClass;
+
     return (
-      <button onClick={this.showMoreNodes}>
+      <button className={pclass('button button-action')} onClick={this.showMoreNodes}>
         {numHiddenChildren} more nodes...
       </button>
     );

--- a/app/js/components/node.jsx
+++ b/app/js/components/node.jsx
@@ -359,9 +359,9 @@ var Node = React.createClass({
 
           //DELAY CHANGE FOR THE HIGHLIGHT
           setTimeout(function(){
-            children = this.createChildren(snapshot, options);
-
-            this.setState(newChildrenState);
+            this.setState({
+              children: this.createChildren(snapshot, options)
+            });
           }.bind(this), 1000);
         }
         else {
@@ -389,11 +389,10 @@ var Node = React.createClass({
   * Creates the child nodes for the current node
   * @param {Firebase Snapshot} snapshot - snapshot at a location
   * @param {Object} options - display options
-  * @param
   * @return {Array[React Nodes]} children - children to render
   */
 
-  createChildren: function(snapshot, options, numToRender, offset) {
+  createChildren: function(snapshot, options) {
     options = options || {};
     var expandAll = options.expandAll || false;
     var collapseAll = options.collapseAll || false;
@@ -433,8 +432,7 @@ var Node = React.createClass({
   * revealMoreNodesNotification
   *
   * render a "x more nodes" notification at the end of a long list of data
-  * @param {Number} numChildrenInSnapshot - number of children in a snapshot
-  * @param {Number} numChildrenDisplayed - number of children displayed in UI
+  * @param {Number} numHiddenChildren - number of children not displayed
   * @param {React DOM} - a "x more nodes" notification
   */
 
@@ -448,6 +446,12 @@ var Node = React.createClass({
     );
   },
 
+
+  /*
+  * showMoreNodes
+  *
+  * update component state to indicate that DEFAULT_DISPLAY_NODES more nodes are showing
+  */
 
   showMoreNodes: function() {
     var newNodesShowing = this.state.nodesShowing + this.DEFAULT_DISPLAY_NODES;

--- a/app/js/components/node.jsx
+++ b/app/js/components/node.jsx
@@ -13,6 +13,7 @@ var AppMixins = require('./mixins');
 */
 
 var Node = React.createClass({
+  UPDATE_BUFFER: 50, // ms
   mixins: [AppMixins],
   timeout: null,
   updateTimeout: null,
@@ -375,7 +376,7 @@ var Node = React.createClass({
         name: name,
         value: snapshot.val()
       });
-    }.bind(this), 50);
+    }.bind(this), this.UPDATE_BUFFER);
   },
 
 

--- a/app/js/components/node.jsx
+++ b/app/js/components/node.jsx
@@ -539,7 +539,7 @@ var Node = React.createClass({
     var pclass = this.prefixClass;
 
     if(!this.state.name) {
-      nodeValue = <em className={pclass('value')}>Loading...</em>;
+      nodeValue = <em className={pclass('value')}>Loading... (this may take a while if you have a lot of data)</em>;
     }
     else if(isRoot && isNull) {
       nodeValue = <em className={pclass('value')}>null</em>;

--- a/app/js/components/node.jsx
+++ b/app/js/components/node.jsx
@@ -14,7 +14,7 @@ var AppMixins = require('./mixins');
 
 var Node = React.createClass({
   DEFAULT_DISPLAY_NODES: 1000,  // NODES TO DISPLAY IN UI
-  UPDATE_BUFFER: 50,            // MILLISECONDS
+  UPDATE_DEBOUNCE: 50,          // MILLISECONDS
   mixins: [AppMixins],
   timeout: null,
   updateTimeout: null,
@@ -73,7 +73,7 @@ var Node = React.createClass({
       hasChildren: false,
       numChildren: 0,
       children: [],
-      nodesShowing: this.DEFAULT_DISPLAY_NODES,
+      numNodesShowing: this.DEFAULT_DISPLAY_NODES,
       name: '',
       value: null,
       expanded: this.props.expandAll === true ? true : false,
@@ -379,7 +379,7 @@ var Node = React.createClass({
         name: name,
         value: snapshot.val()
       });
-    }.bind(this), this.UPDATE_BUFFER);
+    }.bind(this), this.UPDATE_DEBOUNCE);
   },
 
 
@@ -438,10 +438,18 @@ var Node = React.createClass({
 
   revealMoreNodesNotification: function(numHiddenChildren) {
     var pclass = this.prefixClass;
+    var message;
+
+    if (numHiddenChildren > this.DEFAULT_DISPLAY_NODES) {
+      message = "Show next " + this.DEFAULT_DISPLAY_NODES + " of " + numHiddenChildren + " remaining nodes...";
+    }
+    else {
+      message = "Show remaining " + numHiddenChildren + " nodes...";
+    }
 
     return (
       <button className={pclass('button button-action')} onClick={this.showMoreNodes}>
-        {numHiddenChildren} more nodes...
+        {message}
       </button>
     );
   },
@@ -454,14 +462,14 @@ var Node = React.createClass({
   */
 
   showMoreNodes: function() {
-    var newNodesShowing = this.state.nodesShowing + this.DEFAULT_DISPLAY_NODES;
+    var newNodesShowing = this.state.numNodesShowing + this.DEFAULT_DISPLAY_NODES;
 
     if (newNodesShowing > this.state.children.length) {
       newNodesShowing = this.state.children.length;
     }
 
     this.setState({
-      nodesShowing: newNodesShowing
+      numNodesShowing: newNodesShowing
     });
   },
 
@@ -556,8 +564,8 @@ var Node = React.createClass({
   renderChildren: function() {
     var children = {};
     var pclass = this.prefixClass;
-    var numNodesHidden = this.state.children.length - this.state.nodesShowing;
-    var nodesToShow = this.state.children.slice(0, this.state.nodesShowing);
+    var numNodesHidden = this.state.children.length - this.state.numNodesShowing;
+    var nodesToShow = this.state.children.slice(0, this.state.numNodesShowing);
 
     // IF NODES ARE STILL HIDDEN, APPEND THE SHOW MORE NODES BUTTON
     if (numNodesHidden > 0) {


### PR DESCRIPTION
This PR cuts down on the time the "Loading..." notification stays on screen by incrementally rendering only 1000 nodes at a time, saving render time. A "x more nodes" button is rendered that allows the user to render more nodes.