### PR TITLE
Fixes firebase/vulcan#32

### DIFF
--- a/chrome-extension/manifest.json
+++ b/chrome-extension/manifest.json
@@ -15,6 +15,6 @@
   "permissions": [
     "storage"
   ],
-  "content_security_policy": "script-src 'self' 'unsafe-eval'; object-src 'self'",
+  "content_security_policy": "script-src 'self' 'unsafe-eval' https://*.firebaseio.com; object-src 'self'",
   "devtools_page": "devtools.html"
 }


### PR DESCRIPTION
When Vulcan was running in Chrome Dev Tools, a [Content Security Policy](https://developer.chrome.com/extensions/contentSecurityPolicy) violation was preventing resources from being loaded from https://*.firebaseio.com.