### PR TITLE
Remove grunt-react, use browserify+reactify only

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -8,26 +8,18 @@ module.exports = function(grunt) {
     pkg: grunt.file.readJSON('package.json'),
 
     browserify: {
-      account_dev: {
-        options: {
-          debug: true
-        },
+      production: {
         files: {
-          'production/js/vulcan.js': ['tmp/js/vulcan.js']
+          'production/js/vulcan.js': ['app/js/vulcan.jsx']
+        },
+        options: {
+          transform: ['reactify'],
+          browserifyOptions: {
+            debug: true,
+            extensions: ['.js', '.jsx']
+          }
         }
       }
-    },
-
-    react: {
-      client: {
-        files: [{
-          expand: true,
-          cwd: 'app/js',
-          src: ['**/*.js', '**/*.jsx'],
-          dest: 'tmp/js',
-          ext: '.js'
-        }]
-      },
     },
 
     uglify: {
@@ -139,7 +131,7 @@ module.exports = function(grunt) {
 
       js: {
         files: ['app/js/**/*'],
-        tasks: ['react', 'browserify', 'copy:chrome']
+        tasks: ['browserify', 'copy:chrome']
       },
 
       html: {
@@ -160,8 +152,8 @@ module.exports = function(grunt) {
     }
   });
 
-  grunt.registerTask('build:production', ['sass', 'autoprefixer', 'react', 'browserify', 'uglify', 'copy:html', 'copy:bower', 'copy:images', 'copy:chrome', 'compress', 'clean']);
-  grunt.registerTask('build:development', ['sass', 'autoprefixer', 'react', 'browserify', 'copy:html', 'copy:bower', 'copy:images', 'copy:chrome', 'clean']);
+  grunt.registerTask('build:production', ['sass', 'autoprefixer', 'browserify', 'uglify', 'copy:html', 'copy:bower', 'copy:images', 'copy:chrome', 'compress', 'clean']);
+  grunt.registerTask('build:development', ['sass', 'autoprefixer', 'browserify', 'copy:html', 'copy:bower', 'copy:images', 'copy:chrome', 'clean']);
 
   //DEVELOPMENT FOR WEB PLATFORM
   grunt.registerTask('dev', ['build:development', 'connect', 'watch']);

--- a/app/html/index.html
+++ b/app/html/index.html
@@ -13,7 +13,7 @@
 
   <!-- VULCAN & FIRBASE DEPENDANCIES -->
   <link rel="stylesheet" type="text/css" href="css/vulcan.css">
-  <script src="https://cdn.firebase.com/js/client/2.2.3/firebase.js"></script>
+  <script src="bower_components/firebase/firebase-debug.js"></script>
   <script type="text/javascript" src="js/vulcan.js"></script>
 
   <title>VULCAN - Realtime Data Manager</title>

--- a/app/js/vulcan.jsx
+++ b/app/js/vulcan.jsx
@@ -22,34 +22,6 @@
 * @typechecks static-only
 */
 
-
-/*! @license
-*  grunt-react
-*
-*  Copyright (c) 2013 Eric Clemmons
-
-* Permission is hereby granted, free of charge, to any person
-* obtaining a copy of this software and associated documentation
-* files (the "Software"), to deal in the Software without
-* restriction, including without limitation the rights to use,
-* copy, modify, merge, publish, distribute, sublicense, and/or sell
-* copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following
-* conditions:
-
-* The above copyright notice and this permission notice shall be
-* included in all copies or substantial portions of the Software.
-
-* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
-* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
-* OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
-* NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
-* HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
-* WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
-* OTHER DEALINGS IN THE SOFTWARE.
-*/
-
 /*! @license
 
 Firebase Vulcan - License: MIT
@@ -81,7 +53,6 @@ SOFTWARE.
 */
 
 var React = require('react/addons');
-window.React = React;
 var Wrapper = require('./components/container');
 
 

--- a/chrome-extension/panes/index.html
+++ b/chrome-extension/panes/index.html
@@ -12,7 +12,6 @@
     <link rel="stylesheet" type="text/css" href="css/vulcan.css">
 
     <script type="text/javascript" src="bower_components/firebase/firebase.js"></script>
-    <script type="text/javascript" src="bower_components/react/react-with-addons.js"></script>
     <script type="text/javascript" src="js/vulcan.js"></script>
 
   </head>

--- a/package.json
+++ b/package.json
@@ -11,19 +11,19 @@
   "bugs": {
     "url": "https://github.com/firebase/vulcan/issues"
   },
-  "dependencies": {},
   "devDependencies": {
-    "grunt": "~0.4.2",
-    "grunt-autoprefixer": "~0.6.5",
-    "grunt-browserify": "~1.3.0",
-    "grunt-contrib-clean": "~0.5.0",
-    "grunt-contrib-compress": "^0.11.0",
-    "grunt-contrib-connect": "~0.5.0",
-    "grunt-contrib-copy": "~0.5.0",
-    "grunt-contrib-uglify": "^0.5.1",
-    "grunt-contrib-watch": "~0.5.2",
-    "grunt-react": "~0.6.0",
-    "grunt-sass": "^0.10.0",
-    "load-grunt-tasks": "~0.3.0"
+    "grunt": "0.4.5",
+    "grunt-autoprefixer": "3.0.3",
+    "grunt-browserify": "3.8.0",
+    "grunt-contrib-clean": "0.6.0",
+    "grunt-contrib-compress": "0.13.0",
+    "grunt-contrib-connect": "0.10.1",
+    "grunt-contrib-copy": "0.8.0",
+    "grunt-contrib-uglify": "0.9.1",
+    "grunt-contrib-watch": "0.6.1",
+    "grunt-sass": "1.0.0",
+    "load-grunt-tasks": "3.2.0",
+    "react": "0.11.2",
+    "reactify": "0.11.1"
   }
 }


### PR DESCRIPTION
`grunt-react` was depending on an esprima branch that was deleted. This
caused npm install to break.